### PR TITLE
Fix for vlan member port addition happens with invalid interface names (#256)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -715,6 +715,10 @@ def add_vlan_member(ctx, vid, interface_name, untagged):
         else:
             ctx.fail("{} is already a member of {}".format(interface_name,
                                                         vlan_name))
+
+    if interface_name_is_valid(interface_name) is False:
+        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+
     members.append(interface_name)
     vlan['members'] = members
     db.set_entry('VLAN', vlan_name, vlan)


### PR DESCRIPTION
… (#256)

commit b3c17cd9490f4a07358c08fab6515733655411de (HEAD -> azure-256)
Author: ashokkms <ashokkms@aviznetworks.com>
Date:   Tue Jan 29 21:26:07 2019 -0800

    Fix for vlan member port addition happens with invalid interface names (#256)

    Signed-off-by: Ashok kms ashokkms@aviznetworks.com

What I did 
Added interface check while adding vlan member ports to ensure the interface name is correct.

How I did 
Checked the vlan member port against port name in the PORT_TABLE to ensure it's valid.  

How to verify it 
Add an invalid interface name to a vlan and check CLI throws error.

root@sonic:/home/sonic# config vlan member add 500 Ethernet11111
Usage: config vlan member add [OPTIONS] <vid> <interface_name>

Error: Interface name is invalid. Please enter a valid interface name!!
root@sonic:/home/sonic#
